### PR TITLE
Cmake and windows fixes.

### DIFF
--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -185,7 +185,7 @@ void smb2_fd_event_callbacks(struct smb2_context *smb2,
  *      used and must be freed by calling smb2_destroy_context().
  *
  */
-t_socket smb2_service(struct smb2_context *smb2, int revents);
+int smb2_service(struct smb2_context *smb2, int revents);
 
 /*
  * Called to process the events when events become available for the smb2
@@ -202,7 +202,7 @@ t_socket smb2_service(struct smb2_context *smb2, int revents);
  *      used and must be freed by calling smb2_destroy_context().
  *
  */
-t_socket smb2_service_fd(struct smb2_context *smb2, t_socket fd, int revents);
+int smb2_service_fd(struct smb2_context *smb2, t_socket fd, int revents);
 
 /*
  * Set the timeout in seconds after which a command will be aborted with

--- a/include/smb2/smb2.h
+++ b/include/smb2/smb2.h
@@ -660,7 +660,7 @@ struct smb2_ace {
          * SMB2_DENIED_ALLOWED_CALLBACK_ACE_TYPE,
          * SMB2_SYSTEM_RESOURCE_ATTRIBUTE_ACE_TYPE
          */
-        int   ad_len;
+        size_t ad_len;
         char *ad_data;
 
         /* raw blob, used for unknown ACE types */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -47,8 +47,20 @@ set(SOURCES aes.c
             unicode.c
 	    usha.c)
 
-add_library(smb2 ${SOURCES})
+set(INCLUDE_PATH ../include)
+set(SMB2_INCLUDE "${INCLUDE_PATH}/smb2")
+set(HEADERS
+    ${SMB2_INCLUDE}/libsmb2-dcerpc-lsa.h
+    ${SMB2_INCLUDE}/libsmb2-dcerpc-srvsvc.h
+    ${SMB2_INCLUDE}/libsmb2-dcerpc.h
+    ${SMB2_INCLUDE}/libsmb2-raw.h
+    ${SMB2_INCLUDE}/libsmb2.h
+    ${SMB2_INCLUDE}/smb2-errors.h
+    ${SMB2_INCLUDE}/smb2.h)
+
+add_library(smb2 ${SOURCES} ${HEADERS})
 target_link_libraries(smb2 PUBLIC ${core_DEPENDS} ${CORE_LIBRARIES})
+target_include_directories(smb2 PUBLIC ${INCLUDE_PATH})
 set_target_properties(smb2 PROPERTIES
                            VERSION ${PROJECT_VERSION}
                            SOVERSION ${SOVERSION})

--- a/lib/compat.c
+++ b/lib/compat.c
@@ -423,7 +423,7 @@ int poll(struct pollfd *fds, unsigned int nfds, int timo)
         for (i = 0; i < nfds; ++i) {
                 int fd = fds[i].fd;
                 fds[i].revents = 0;
-                if (fd < 0)
+                if (!VALID_SOCKET(fd))
                         continue;
                 if(fds[i].events & (POLLIN|POLLPRI)) {
                         ip = &ifds;
@@ -494,7 +494,7 @@ int poll(struct pollfd *fds, unsigned int nfds, int timo)
                 int fd = fds[i].fd;
                 short events = fds[i].events;
                 short revents = 0;
-                if (fd < 0)
+                if (!VALID_SOCKET(fd))
                         continue;
                 if(events & (POLLIN|POLLPRI) && FD_ISSET(fd, &ifds))
                         revents |= POLLIN;

--- a/lib/compat.h
+++ b/lib/compat.h
@@ -61,8 +61,11 @@ typedef unsigned int uintptr_t;
 
 #if defined(_WINDOWS) || defined(_XBOX)
 typedef SOCKET t_socket;
+#define VALID_SOCKET(sock)	((sock) != INVALID_SOCKET)
 #else
 typedef int t_socket;
+#define VALID_SOCKET(sock)	((sock) >= 0)
+#define INVALID_SOCKET		-1
 #endif
 
 #ifndef ENETRESET

--- a/lib/init.c
+++ b/lib/init.c
@@ -277,7 +277,7 @@ struct smb2_context *smb2_init_context(void)
 
         ret = getlogin_r(buf, sizeof(buf));
         smb2_set_user(smb2, ret == 0 ? buf : "Guest");
-        smb2->fd = -1;
+        smb2->fd = INVALID_SOCKET;
         smb2->connecting_fds = NULL;
         smb2->connecting_fds_count = 0;
         smb2->addrinfos = NULL;
@@ -306,12 +306,12 @@ void smb2_destroy_context(struct smb2_context *smb2)
                 return;
         }
 
-        if (smb2->fd != -1) {
+        if (VALID_SOCKET(smb2->fd)) {
                 if (smb2->change_fd) {
                         smb2->change_fd(smb2, smb2->fd, SMB2_DEL_FD);
                 }
                 close(smb2->fd);
-                smb2->fd = -1;
+                smb2->fd = INVALID_SOCKET;
         }
         else {
                 smb2_close_connecting_fds(smb2);

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -190,12 +190,12 @@ smb2_close_context(struct smb2_context *smb2)
                 return;
         }
 
-        if (smb2->fd != -1) {
+        if (VALID_SOCKET(smb2->fd)) {
                 if (smb2->change_fd) {
                         smb2->change_fd(smb2, smb2->fd, SMB2_DEL_FD);
                 }
                 close(smb2->fd);
-                smb2->fd = -1;
+                smb2->fd = INVALID_SOCKET;
         }
 
         smb2->message_id = 0;
@@ -2537,7 +2537,7 @@ disconnect_cb_2(struct smb2_context *smb2, int status,
                 smb2->change_fd(smb2, smb2->fd, SMB2_DEL_FD);
         }
         close(smb2->fd);
-        smb2->fd = -1;
+        smb2->fd = INVALID_SOCKET;
 }
 
 static void
@@ -2567,7 +2567,7 @@ smb2_disconnect_share_async(struct smb2_context *smb2,
                 return -EINVAL;
         }
 
-        if (smb2->fd == -1) {
+        if (!VALID_SOCKET(smb2->fd)) {
                 smb2_set_error(smb2, "connection is alreeady disconnected or was never connected");
                 return -EINVAL;
         }

--- a/lib/sync.c
+++ b/lib/sync.c
@@ -85,7 +85,7 @@ static int wait_for_reply(struct smb2_context *smb2,
                 if (smb2->timeout) {
                         smb2_timeout_pdus(smb2);
                 }
-		if (smb2->fd == -1 && ((time(NULL) - t) > (smb2->timeout)))
+		if (!VALID_SOCKET(smb2->fd) && ((time(NULL) - t) > (smb2->timeout)))
 		{
 			smb2_set_error(smb2, "Timeout expired and no connection exists\n");
 			return -1;
@@ -93,7 +93,7 @@ static int wait_for_reply(struct smb2_context *smb2,
 #if defined (PS2_EE_PLATFORM) && defined(PS2IPS)
                 /* select() is broken on ps2ips :-( */
                 pfd.revents |= POLLOUT;
-                if (smb2->fd != -1) {
+                if (VALID_SOCKET(smb2->fd)) {
                         pfd.revents |= POLLIN;
                 }
 #endif                
@@ -870,7 +870,7 @@ int smb2_echo(struct smb2_context *smb2)
         struct sync_cb_data *cb_data;
         int rc = 0;
 
-        if (smb2->fd == -1) {
+        if (VALID_SOCKET(smb2->fd)) {
                 smb2_set_error(smb2, "Not Connected to Server");
                 return -ENOMEM;
         }


### PR DESCRIPTION
This branch has changes that fix execution under windows where the SOCKET (t_socket) type is unsigned. And also a small edit to the include paths attached to the smb2 target to make it work with external code properly.